### PR TITLE
Fix: Bluetooth advertising

### DIFF
--- a/config/boards/shields/DM5x6/Kconfig.shield
+++ b/config/boards/shields/DM5x6/Kconfig.shield
@@ -1,5 +1,5 @@
 config SHIELD_DM5X6_LEFT
-    def_bool $(shields_list_contains, DM5x6_left)
+    def_bool $(shields_list_contains,DM5x6_left)
 
 config SHIELD_DM5X6_RIGHT
-    def_bool $(shields_list_contains, DM5x6_right)
+    def_bool $(shields_list_contains,DM5x6_right)


### PR DESCRIPTION
Hey, thanks very much for sharing your config.  Your config was perfect for my hand wired dactyl and as a general introduction to ZMK.  

The issue i had was that bluetooth wouldn't advertise -  I couldn't see it in windows/osx/linux, however,  it worked over USB.  After a couple of nights of trial and error, it turns out there's not supposed to be a space in the config!

Just posting this in case anyone else has this issue